### PR TITLE
feat: add kaos-debug-skills plugin and kaos-prd-sprint orchestrator

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,14 +10,26 @@
     {
       "name": "kaos-prd-skills",
       "source": "./plugins/kaos-prd-skills",
-      "description": "Full KAOS PRD lifecycle — create, start, advance, track progress, capture decisions, and complete Product Requirements Documents. Includes automated PRD update reminders via hooks.",
-      "version": "1.2.0",
+      "description": "Full KAOS PRD lifecycle — create, start, advance, track progress, capture decisions, and complete Product Requirements Documents. Includes sprint orchestrator and automated PRD update reminders via hooks.",
+      "version": "1.3.0",
       "author": {
         "name": "KubeCore"
       },
       "homepage": "https://kaos.kubecore.eu",
       "category": "productivity",
       "tags": ["prd", "product", "kaos", "kubernetes", "gitops"]
+    },
+    {
+      "name": "kaos-debug-skills",
+      "source": "./plugins/kaos-debug-skills",
+      "description": "KAOS platform debugging, composition troubleshooting, and plan-and-delegate workflow skills. Structured RCA, Crossplane composition validation, and streamlined agent delegation.",
+      "version": "1.0.0",
+      "author": {
+        "name": "KubeCore"
+      },
+      "homepage": "https://kaos.kubecore.eu",
+      "category": "productivity",
+      "tags": ["debug", "troubleshoot", "composition", "crossplane", "workflow", "kaos"]
     },
     {
       "name": "kaos-kubeapp-skills",

--- a/plugins/kaos-debug-skills/.claude-plugin/plugin.json
+++ b/plugins/kaos-debug-skills/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "kaos-debug-skills",
+  "version": "1.0.0",
+  "description": "KAOS platform debugging, composition troubleshooting, and plan-and-delegate workflow skills. Breaks debug loops with structured RCA, validates Crossplane compositions, and streamlines plan→delegate workflows.",
+  "author": {
+    "name": "KubeCore",
+    "email": "hello@kaos.kubecore.eu"
+  },
+  "homepage": "https://kaos.kubecore.eu",
+  "license": "Apache-2.0"
+}

--- a/plugins/kaos-debug-skills/hooks/hooks.json
+++ b/plugins/kaos-debug-skills/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo 'If the user just pasted an error for the 3rd+ time on the same issue, suggest /kaos-debug for structured root-cause analysis instead of continuing ad-hoc fixes.'"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/kaos-debug-skills/skills/kaos-composition-debug/SKILL.md
+++ b/plugins/kaos-debug-skills/skills/kaos-composition-debug/SKILL.md
@@ -1,0 +1,227 @@
+---
+name: kaos-composition-debug
+description: Crossplane composition-specific debugging. Validates composition-XRD alignment, traces patch chains, checks runtime providers, compares rendered vs expected manifests, and verifies RBAC and ProviderConfig.
+user-invocable: true
+---
+
+# KAOS Composition Debug
+
+Systematic debugging workflow for Crossplane compositions and XRDs on the KAOS platform. Walks through every layer where composition issues can occur: definition alignment, provider health, patch chain integrity, rendered resource accuracy, and RBAC/ProviderConfig validity.
+
+**Follow the steps in order. Do not skip steps — composition issues often have multiple contributing causes.**
+
+## Usage
+
+```
+/kaos-composition-debug
+/kaos-composition-debug [composition-name or xrd-name]
+/kaos-composition-debug [xr-type/xr-name]
+```
+
+## Process
+
+---
+
+### Step 1: Identify Target
+
+Determine which composition/XRD to investigate.
+
+**If the user named a specific resource:** use it directly.
+
+**If not — detect from context:**
+1. Check for recent errors in operator logs mentioning composition issues
+2. Look for XRs in non-Ready state: `kubectl get composite -A`
+3. Ask the user which composition or XR is problematic
+
+**Gather baseline data:**
+```bash
+kubectl get xrd                    # All XRD definitions
+kubectl get composition            # All compositions
+kubectl get composite -A           # All composite resources (XRs)
+```
+
+Identify the specific:
+- **XRD** (CompositeResourceDefinition)
+- **Composition** (that targets the XRD)
+- **XR** (live composite resource instance, if one exists)
+
+---
+
+### Step 2: Validate Composition ↔ XRD Alignment
+
+Get both resources and compare:
+
+```bash
+kubectl get xrd <xrd-name> -o yaml
+kubectl get composition <composition-name> -o yaml
+```
+
+**Check these alignment points:**
+
+| Check | How | Common Failure |
+|-------|-----|----------------|
+| `compositeTypeRef` matches | Composition `spec.compositeTypeRef.apiVersion` and `kind` must match XRD's `spec.group` + `spec.names.kind` | Typo in apiVersion or kind |
+| Schema fields exist | Every `fromFieldPath` in patches must reference a field that exists in the XRD's OpenAPI schema | Field renamed in XRD but not in composition |
+| Required fields have defaults | XRD required fields without defaults will cause validation failures | Missing default in XRD schema |
+| Version alignment | Composition targets the correct XRD version (`spec.compositeTypeRef.apiVersion`) | Version mismatch after XRD update |
+
+**Present findings:**
+```markdown
+## Composition ↔ XRD Alignment
+
+| Check | Status | Details |
+|-------|--------|---------|
+| compositeTypeRef | ✓/✗ | [details] |
+| Schema field coverage | ✓/✗ | [missing fields if any] |
+| Required field defaults | ✓/✗ | [fields missing defaults] |
+| Version match | ✓/✗ | [versions] |
+```
+
+---
+
+### Step 3: Check Runtime Providers
+
+Compositions depend on Crossplane providers being installed and healthy.
+
+```bash
+kubectl get providers                          # All installed providers
+kubectl get providerconfig                     # All provider configurations
+kubectl get controllerconfig 2>/dev/null       # Controller configs (if any)
+```
+
+**For each provider used by the composition:**
+- Is it installed? (`kubectl get provider <name>`)
+- Is it healthy? (check `Ready` condition)
+- Does the ProviderConfig it references exist?
+
+```markdown
+## Provider Health
+
+| Provider | Installed | Healthy | ProviderConfig Exists |
+|----------|-----------|---------|----------------------|
+| [name] | ✓/✗ | ✓/✗ | ✓/✗ |
+```
+
+---
+
+### Step 4: Trace Patch Chains
+
+This is the most common source of composition issues. For each patch in the composition:
+
+```bash
+kubectl get composition <name> -o json | jq '.spec.resources[].patches[]'
+```
+
+**For each patch, verify:**
+1. `fromFieldPath` — does this field exist and have a value in the XR?
+2. `toFieldPath` — is this a valid path in the composed resource schema?
+3. `transforms` — are transform functions correct (map, convert, string)?
+4. `policy.fromFieldPath` — is it `Required` or `Optional`? A `Required` patch with a missing source value will block the resource.
+
+**If a live XR exists, verify actual values:**
+```bash
+kubectl get <xr-type> <xr-name> -o yaml
+```
+
+**Present as a patch flow diagram:**
+```markdown
+## Patch Chain Analysis
+
+| Resource | From | → | To | Value | Status |
+|----------|------|---|-----|-------|--------|
+| [resource-name] | spec.parameters.region | → | spec.forProvider.region | "eu-west-1" | ✓ |
+| [resource-name] | spec.parameters.size | → | spec.forProvider.instanceClass | null | ✗ MISSING |
+```
+
+Flag any patches where the source value is null, empty, or mismatched type.
+
+---
+
+### Step 5: Rendered vs Expected
+
+If a live XR exists, compare what was actually composed against what the composition should have produced.
+
+```bash
+# Get composed resources from the XR
+kubectl get <xr-type> <xr-name> -o jsonpath='{.spec.resourceRefs}'
+```
+
+For each composed resource:
+```bash
+kubectl get <kind> <name> -o yaml
+```
+
+**Compare key fields:**
+- Do patched fields have the expected values?
+- Are there fields that should have been set but are missing?
+- Are there unexpected default values overriding patches?
+
+```markdown
+## Rendered vs Expected
+
+| Resource | Field | Expected | Actual | Match |
+|----------|-------|----------|--------|-------|
+| [name] | spec.forProvider.region | eu-west-1 | eu-west-1 | ✓ |
+| [name] | spec.forProvider.vpcId | vpc-abc123 | (empty) | ✗ |
+```
+
+---
+
+### Step 6: RBAC and ProviderConfig
+
+Check if the Crossplane provider has permission to create the resources the composition specifies.
+
+**Identify the provider ServiceAccount:**
+```bash
+kubectl get provider <provider-name> -o jsonpath='{.status.currentRevision}'
+kubectl get pods -n crossplane-system -l pkg.crossplane.io/revision=<revision> -o jsonpath='{.items[0].spec.serviceAccountName}'
+```
+
+**Check permissions for each composed resource type:**
+```bash
+kubectl auth can-i create <resource> --as=system:serviceaccount:crossplane-system:<sa-name>
+kubectl auth can-i update <resource> --as=system:serviceaccount:crossplane-system:<sa-name>
+```
+
+**Check ProviderConfig references:**
+For each composed resource that references a ProviderConfig:
+```bash
+kubectl get providerconfig <name> 2>/dev/null
+```
+
+```markdown
+## RBAC & ProviderConfig
+
+| Check | Resource | Result |
+|-------|----------|--------|
+| Can create | [resource-type] | ✓/✗ |
+| ProviderConfig exists | [config-name] | ✓/✗ |
+```
+
+---
+
+### Step 7: Diagnosis Summary
+
+Compile all findings into a structured diagnosis:
+
+```markdown
+## Composition Diagnosis
+
+**Resource:** [composition/xrd/xr name]
+
+**Root Cause:** [The specific issue found — which step revealed it]
+
+**Details:**
+[Specific field, patch, RBAC rule, or ProviderConfig that is the problem]
+
+**Recommended Fix:**
+[Exact changes to make — file paths, field values, or commands]
+
+**Verification:**
+After applying the fix:
+1. Re-apply the composition: `kubectl apply -f <composition-file>`
+2. Check XR status: `kubectl get <xr-type> <xr-name> -o yaml`
+3. Monitor with: `kaos-watch.sh <xr-type>/<xr-name> --show-tree --until Ready`
+```
+
+If no single root cause is found but multiple issues exist, list them in priority order (fix the first one, then re-run this skill).

--- a/plugins/kaos-debug-skills/skills/kaos-composition-debug/manifest.json
+++ b/plugins/kaos-debug-skills/skills/kaos-composition-debug/manifest.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "../../../../manifest.schema.json",
+  "name": "kaos-composition-debug",
+  "type": "skill",
+  "version": "1.0.0",
+  "entry": "SKILL.md",
+  "description": "Crossplane composition-specific debugging. Validates composition-XRD alignment, traces patch chains, checks runtime providers, compares rendered vs expected manifests, and verifies RBAC/ProviderConfig.",
+  "produces": {
+    "chunk_types": [],
+    "label": "",
+    "output_path": ""
+  },
+  "consumes": {
+    "chunk_types": ["kubepool", "kubeorg", "kubeproject", "kubeapp"],
+    "tools": ["kaos:get", "kaos:list", "kaos:diagnose", "kaos:schema", "kaos:knowledge"]
+  },
+  "dependencies": {
+    "skills": []
+  },
+  "tags": ["composition", "crossplane", "xrd", "debug", "patch", "kaos"],
+  "author": "kaos-io",
+  "license": "Apache-2.0"
+}

--- a/plugins/kaos-debug-skills/skills/kaos-composition-debug/references/composition-architecture.md
+++ b/plugins/kaos-debug-skills/skills/kaos-composition-debug/references/composition-architecture.md
@@ -1,0 +1,117 @@
+# KAOS Composition Architecture Reference
+
+Reference document for the `/kaos-composition-debug` skill. Documents the Crossplane composition hierarchy and router pattern used by the KAOS platform.
+
+---
+
+## Resource Hierarchy and XR Mapping
+
+```
+KubeOrg (Organization) — cloud-agnostic phases, OrgCompositionRouter dispatch
+├── XAWSProvider ({org}-awsprovider)
+├── XGithubProvider ({org}-githubprovider)
+├── XAwsNetwork ({org}-{region}-network)
+└── GitHub Secret ({org}-github-credentials)
+
+KubePool (Cluster) — cloud-agnostic phases, CompositionRouter dispatch
+├── XEKS ({pool}-eks)
+└── XKubeSystem ({pool}-system)
+    ├── Release/argocd
+    ├── Release/external-dns
+    ├── Release/cert-manager
+    ├── Release/external-secrets
+    └── Release/... (platform tools)
+
+KubeProject (Project)
+├── XGitHubProject ({project}-github)
+└── XKubEnv ({project}-{env}-kubenv)
+
+KubeApp (Application)
+├── XGitHubApp ({app}-github)
+└── XK8sApp ({app}-k8s)
+```
+
+---
+
+## Composition Directory Structure
+
+All compositions live in `compositions/apis/`:
+
+```
+compositions/apis/
+├── kubeorg/
+│   ├── awsprovider/        # XAWSProvider composition
+│   │   ├── definition.yaml
+│   │   ├── composition.yaml
+│   │   └── tests/
+│   ├── githubprovider/     # XGithubProvider composition
+│   ├── network/            # XAwsNetwork composition
+│   └── ...
+├── kubepool/
+│   ├── aws/
+│   │   └── eks/            # XEKS composition
+│   │       ├── definition.yaml
+│   │       ├── composition.yaml
+│   │       └── tests/
+│   └── system/             # XKubeSystem composition
+│       ├── definition.yaml
+│       ├── composition.yaml
+│       └── tests/
+├── kubeproject/
+│   ├── githubproject/      # XGitHubProject composition
+│   └── kubenv/             # XKubEnv composition
+└── kubeapp/
+    ├── githubapp/          # XGitHubApp composition
+    └── k8sapp/             # XK8sApp composition
+```
+
+---
+
+## Composition Router Pattern
+
+The operator uses composition routers to decouple cloud-specific logic from phase execution:
+
+### KubePool Router
+```go
+// framework.CompositionRouter → CompositionSetContract
+router["aws"] = NewAWSCompositionSet()
+// Adding GCP: router["gcp"] = NewGCPCompositionSet()
+```
+
+### KubeOrg Router
+```go
+// framework.OrgCompositionRouter → OrgCompositionSetContract (4 methods)
+orgRouter["aws"] = NewAWSOrgCompositionSet()
+// Methods: SyncResources, ExtractStatus, CheckHealthy, HandleDeletion
+```
+
+---
+
+## Key Conventions
+
+- **Namespacing:** XRs are namespaced in the org namespace (CON-12)
+- **Parameters:** All composition input via `spec.parameters` (CON-13), no EnvironmentConfig
+- **Naming:** XR names follow `{resource-name}-{suffix}` pattern
+- **Labels:** All composed resources carry `platform.kubecore.io/` labels for hierarchy tracking
+- **ProviderConfig:** Each org has its own ProviderConfig (`{org}-kubernetes`, `{org}-aws`, etc.)
+
+---
+
+## Common Composition Issues by Layer
+
+### Definition (XRD) Layer
+- Missing field in OpenAPI schema → patch fromFieldPath fails silently
+- Wrong API version → claims can't be created
+- Missing `status.subresources` → status never propagates
+
+### Composition Layer
+- `compositeTypeRef` mismatch with XRD → composition never matches
+- Patch `fromFieldPath` referencing non-existent field → null values in composed resources
+- Missing `connectionDetails` → secrets not propagated
+- Wrong `base` manifest apiVersion → Crossplane can't create the resource
+
+### Provider Layer
+- Provider not installed → composed resources stuck as Pending
+- ProviderConfig not found → resources fail with "referenced ProviderConfig not found"
+- IRSA role missing permissions → cloud resources fail to create
+- Provider revision mismatch → API version incompatibility

--- a/plugins/kaos-debug-skills/skills/kaos-debug/SKILL.md
+++ b/plugins/kaos-debug-skills/skills/kaos-debug/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: kaos-debug
+description: Structured debugging that breaks the 3-5 iteration debug loop. Auto-gathers platform state, enforces root cause analysis before fixes, tracks attempts, and requires verification evidence.
+user-invocable: true
+---
+
+# KAOS Debug
+
+Structured debugging workflow that prevents circular fix-retry loops. This skill enforces a strict phase order: gather evidence, analyze root cause, propose fix, verify fix. It tracks every attempt to prevent repeating failed approaches.
+
+**Never propose a fix before completing root cause analysis. Never claim a fix worked without verification evidence.**
+
+## Usage
+
+```
+/kaos-debug
+/kaos-debug [resource-type/name]
+/kaos-debug [description of the issue]
+```
+
+## Process
+
+---
+
+### Phase 1: Auto-Gather Evidence
+
+**Before the user describes the problem**, immediately run a parallel data collection sweep. This establishes baseline state and often reveals the issue without the user needing to paste logs.
+
+**Run these in parallel:**
+
+1. **Platform resource health:**
+   ```
+   kaos:list(resource_type="KubeOrg")
+   kaos:list(resource_type="KubePool")
+   kaos:list(resource_type="KubeProject")
+   kaos:list(resource_type="KubeApp")
+   ```
+   Flag anything not in `Ready` state.
+
+2. **Cluster events** (last 50, sorted by time):
+   ```bash
+   kubectl get events --sort-by=.lastTimestamp -A | tail -50
+   ```
+
+3. **Unhealthy pods:**
+   ```bash
+   kubectl get pods -A --field-selector=status.phase!=Running,status.phase!=Succeeded | head -30
+   ```
+
+4. **Current cluster context:**
+   ```bash
+   kubectl config current-context
+   ```
+
+5. **If a specific resource was named**, run diagnostics on it:
+   ```
+   kaos:diagnose(resource_type="<type>", name="<name>")
+   kaos:get(resource_type="<type>", name="<name>")
+   ```
+
+6. **Operator logs** (last 30 lines):
+   ```bash
+   kubectl logs -n kubecore-system -l app=kubecore-operator --tail=30
+   ```
+
+Consult `references/debug-patterns.md` for known platform quirks that might explain the symptoms (e.g., status endpoint false-failures on delete, 95% stall pattern).
+
+---
+
+### Phase 2: Problem Statement
+
+Present the gathered data to the user as a concise summary:
+
+```markdown
+## Gathered State
+
+| Area | Finding |
+|------|---------|
+| Platform Resources | [summary of non-Ready resources] |
+| Recent Events | [notable warnings/errors] |
+| Unhealthy Pods | [count and notable pods] |
+| Cluster Context | [which cluster we're on] |
+| Operator Logs | [recent errors if any] |
+
+**Which resource or behavior is the actual problem?**
+[If obvious from the data, state your understanding and ask for confirmation]
+```
+
+Wait for the user to confirm the problem scope. Do not proceed without confirmation.
+
+---
+
+### Phase 3: Root Cause Analysis
+
+**This phase is MANDATORY. You MUST NOT propose fixes until the RCA is confirmed.**
+
+Produce a structured root cause analysis:
+
+```markdown
+## Root Cause Analysis
+
+**Symptom:** [What is observed — the user's complaint + your evidence]
+
+### Hypotheses
+
+| # | Hypothesis | Evidence For | Evidence Against | Verdict |
+|---|-----------|-------------|-----------------|---------|
+| 1 | [Potential cause] | [What supports this] | [What contradicts this] | Likely / Unlikely / Needs investigation |
+| 2 | [Another cause] | ... | ... | ... |
+| 3 | [Another cause] | ... | ... | ... |
+
+### Most Likely Root Cause
+
+**[State the verdict]**: [1-2 sentences explaining why this is the most likely cause, referencing specific evidence]
+```
+
+**Rules:**
+- Generate at least 2 hypotheses
+- Each hypothesis must have both "Evidence For" AND "Evidence Against"
+- If you cannot find evidence against a hypothesis, investigate deeper — easy answers are often wrong
+- If a hypothesis requires checking something, check it now (run commands, read files) rather than guessing
+
+Present the RCA and wait for the user to confirm the root cause before proceeding.
+
+---
+
+### Phase 4: Fix Proposal
+
+Only after the user confirms the root cause:
+
+```markdown
+## Proposed Fix
+
+**Root Cause:** [Confirmed cause]
+
+**Fix:**
+[Exact commands, code changes, or manifest modifications — be specific]
+
+**Rollback Plan:**
+[How to undo this fix if it makes things worse]
+
+**Expected Outcome:**
+[What should change after the fix is applied — specific conditions, log messages, or resource states]
+```
+
+Wait for user approval before applying the fix.
+
+---
+
+### Phase 5: Verification
+
+After the fix is applied, **you must verify it worked**:
+
+1. **Re-run the same data collection from Phase 1** — same commands, same queries
+2. **Diff before vs after** — what actually changed?
+3. **Check the Expected Outcome from Phase 4** — does the observed state match?
+4. **Present evidence:**
+
+```markdown
+## Verification
+
+| Check | Before | After | Pass? |
+|-------|--------|-------|-------|
+| [Resource Ready status] | [value] | [value] | ✓/✗ |
+| [Operator logs] | [error] | [clean] | ✓/✗ |
+| [Specific condition] | [state] | [state] | ✓/✗ |
+
+**Result:** [RESOLVED / NOT RESOLVED]
+```
+
+If NOT RESOLVED, update the iteration tracker and return to Phase 3 with new evidence.
+
+---
+
+## Iteration Tracking
+
+Maintain this table across all fix attempts within the session:
+
+```markdown
+## Debug Iteration Log
+
+| Attempt | Hypothesis | Fix Applied | Result | Notes |
+|---------|-----------|------------|--------|-------|
+| 1 | [hypothesis] | [what was done] | [outcome] | [what we learned] |
+| 2 | ... | ... | ... | ... |
+```
+
+**Critical rule:** If the iteration count reaches 3 without resolution:
+- **STOP** proposing fixes from the same hypothesis family
+- **Force pivot** to a fundamentally different hypothesis
+- Consider: Are we debugging the right thing? Is the problem upstream?
+- Suggest escalation options: check a different cluster, review recent git changes, or involve domain expertise
+
+---
+
+## Anti-Patterns to Avoid
+
+1. **Never** say "this should fix it" without verification evidence
+2. **Never** retry the exact same fix that already failed
+3. **Never** skip the RCA phase because the fix seems obvious — obvious fixes that fail waste more time than careful analysis
+4. **Never** assume which cluster context you're on — always check
+5. **Never** ignore the iteration tracker — it prevents circular debugging

--- a/plugins/kaos-debug-skills/skills/kaos-debug/manifest.json
+++ b/plugins/kaos-debug-skills/skills/kaos-debug/manifest.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "../../../../manifest.schema.json",
+  "name": "kaos-debug",
+  "type": "skill",
+  "version": "1.0.0",
+  "entry": "SKILL.md",
+  "description": "Structured debugging skill that breaks the 3-5 iteration debug loop. Auto-gathers platform state, enforces root cause analysis before fixes, tracks attempts, and requires verification evidence.",
+  "produces": {
+    "chunk_types": [],
+    "label": "",
+    "output_path": ""
+  },
+  "consumes": {
+    "chunk_types": ["kubeapp", "kubeproject", "kubepool", "kubeorg"],
+    "tools": ["kaos:status", "kaos:diagnose", "kaos:get", "kaos:list", "kaos:knowledge"]
+  },
+  "dependencies": {
+    "skills": []
+  },
+  "tags": ["debug", "troubleshoot", "root-cause", "rca", "kaos"],
+  "author": "kaos-io",
+  "license": "Apache-2.0"
+}

--- a/plugins/kaos-debug-skills/skills/kaos-debug/references/debug-patterns.md
+++ b/plugins/kaos-debug-skills/skills/kaos-debug/references/debug-patterns.md
@@ -1,0 +1,92 @@
+# KAOS Debug Patterns — Known Platform Quirks
+
+Reference document for the `/kaos-debug` skill. These are verified platform behaviors that should be consulted before diagnosing issues.
+
+---
+
+## Status Endpoint Quirks
+
+### Delete Status False-Failure
+
+`mcp__KAOS__status` returns `INTERNAL_ERROR` with `complete=true, failed=true` when a DELETE operation completes and the resource is already gone. This happens because the status endpoint tries to look up the transaction for the now-deleted resource and fails.
+
+**This is NOT a real failure.** Verification pattern:
+```
+kaos:status(...)  → INTERNAL_ERROR (complete=true, failed=true)
+kaos:list(...)    → resource absent → deletion SUCCEEDED
+```
+
+Always follow a delete status check with `kaos:list()` to confirm the resource is actually gone.
+
+### 95% Stall Pattern
+
+Delete status commonly holds at 95% completion for 1-2 polling cycles before jumping to 100%. This is normal — do not interpret it as a stuck operation.
+
+---
+
+## Provisioning Timings (novelcore org, verified)
+
+These timings are approximate and depend on cloud provider responsiveness:
+
+| Resource | Operation | Typical Duration |
+|----------|-----------|-----------------|
+| KubeProject (2 environments) | Create | ~7 minutes |
+| KubeApp (python-rest-api, small) | Create | ~7-8 minutes |
+| KubeApp | Delete | ~9 minutes (ArgoCD sync is slow) |
+| KubeProject | Delete | ~5 minutes |
+
+If a resource takes significantly longer than these benchmarks, it may genuinely be stuck.
+
+---
+
+## Common Root Causes by Symptom
+
+### "Composition not in runtime"
+1. Check if the XRD definition was applied: `kubectl get xrd`
+2. Check if the composition was applied: `kubectl get composition`
+3. Verify `compositeTypeRef` matches between composition and XRD
+4. Check Crossplane provider health: `kubectl get providers`
+
+### "Resource stuck in Reconciling/Syncing"
+1. Check if child XRs are healthy: `kubectl get <xr-type> -o yaml`
+2. Look for ProviderConfig issues: `kubectl get providerconfig`
+3. Check if RBAC allows the operation: `kubectl auth can-i`
+4. Review operator logs for the specific controller
+
+### "Finalizer preventing deletion"
+1. Identify which finalizer is stuck: `kubectl get <resource> -o jsonpath='{.metadata.finalizers}'`
+2. Check if the finalizer controller is running
+3. For `kubecore.io/wait-for-kubesystem`: child resources must be deleted first
+4. Emergency scripts available at: `scripts/emergency-fix-stuck-kubepool.sh`
+
+### "Secret/credential not reaching target"
+1. Check ExternalSecret/ClusterSecretStore health
+2. Verify PushSecret configuration
+3. Check if the secret exists in the source (AWS Secrets Manager)
+4. Verify IAM roles and IRSA configuration
+
+### "ArgoCD application not syncing"
+1. Check if the ArgoCD Application resource exists in the child cluster
+2. Verify the git repository URL and branch
+3. Check ArgoCD server logs for sync errors
+4. Verify OIDC SSO configuration if login-related
+
+---
+
+## CI/CD Pipeline Names (stable, repo-specific)
+
+| Pipeline | Trigger | Name |
+|----------|---------|------|
+| Dev release | PR merge to dev | "Release to dev environment" |
+| RC creation | Manual dispatch from dev | "Craft RC, release dev to stage" |
+| RC release | Auto on RC branch PR open | "RC release, deploy to stage" |
+| Dev dispatch job | Post-merge | `notify-gitops-repository` |
+| Stage dispatch | Event type | `staging-environment-update` |
+
+---
+
+## Branch Protection on Dev
+
+- Required checks: `validate-pr`, `build-scan-push`, `gate-check` + 1 approving review
+- `build-scan-push` is marked required but shows `skipping` on unlabeled PRs (only runs with `deploy-preview` label)
+- `enforce_admins=false` — use `gh pr merge --admin` for e2e test merges

--- a/plugins/kaos-debug-skills/skills/kaos-plan-and-delegate/SKILL.md
+++ b/plugins/kaos-debug-skills/skills/kaos-plan-and-delegate/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: kaos-plan-and-delegate
+description: Streamlined plan-then-delegate workflow. Generates plans with acceptance criteria and no assumptions, waits for single approval, then auto-spawns the right agent type. All agents default to Sonnet 4.6.
+user-invocable: true
+---
+
+# KAOS Plan and Delegate
+
+Consolidates the "craft a plan → approve → pass to agent" workflow into a single skill invocation. Produces plans in the user's preferred format (numbered acceptance criteria, questions instead of assumptions) and delegates to the appropriate agent after a single approval gate.
+
+**One plan. One approval. One delegation. No back-and-forth.**
+
+## Usage
+
+```
+/kaos-plan-and-delegate
+/kaos-plan-and-delegate [description of the task]
+```
+
+## Process
+
+---
+
+### Step 1: Intake and Domain Detection
+
+Gather the user's request. If insufficient context, ask targeted questions — but never assume.
+
+**Determine the work domain** to select the right agent later:
+
+| Domain | Signals | Agent Target |
+|--------|---------|-------------|
+| **Operator** | Go code, CRDs, controllers, reconciliation, phases, builders | Developer agent (sonnet) |
+| **Compositions** | XRDs, Crossplane, compositions, patches, providers | Developer agent (sonnet) |
+| **Frontend** | React, TypeScript, dashboard, UI, components | Frontend agent (sonnet) |
+| **API** | kaos-graph, kaos-gitops-gateway, REST endpoints | Developer agent (sonnet) |
+| **Testing** | E2E, integration test, platform validation | @kaos-tester agent (sonnet) |
+| **PRD-driven** | Acceptance criteria, feature from PRD, sprint work | Defer to `/kaos-prd-sprint` |
+| **Infrastructure** | Scripts, Helm charts, cluster operations | Developer agent (sonnet) |
+
+If the domain is **PRD-driven**, tell the user to use `/kaos-prd-sprint` instead and stop.
+
+**Query platform context if relevant:**
+```
+kaos:knowledge(query="[topic relevant to the task]")
+kaos:schema(resource_type="[relevant resource]")
+```
+
+---
+
+### Step 2: Plan Generation
+
+Generate the plan in this exact format:
+
+```markdown
+# Plan: [Title — concise, action-oriented]
+
+## Objective
+[1 sentence: what this achieves and why it matters]
+
+## Acceptance Criteria
+1. **AC-01:** [Verifiable condition — not "should work" but "X returns Y when Z"]
+2. **AC-02:** [Another verifiable condition]
+3. **AC-03:** [...]
+
+## Questions
+[List EVERY uncertainty. Do not assume answers. If there are no questions, state "None — requirements are clear."]
+
+- Q1: [Question about ambiguous requirement]
+- Q2: [Question about implementation choice]
+
+## Constraints
+[Only constraints the user has explicitly stated or that are documented in CLAUDE.md/PRD]
+
+## Implementation Steps
+1. [Step with dependency noted if applicable]
+2. [Next step]
+3. [...]
+
+## Verification
+- [ ] [How to verify AC-01]
+- [ ] [How to verify AC-02]
+- [ ] [...]
+
+## Files to Modify
+- `path/to/file.go` — [what changes]
+- `path/to/file.yaml` — [what changes]
+```
+
+**Rules:**
+- Acceptance criteria must be objectively verifiable (not subjective)
+- Questions section is mandatory — if you have zero questions, you probably missed something
+- Implementation steps must be ordered by dependency
+- Include file paths when known
+- Do not pad with unnecessary steps — keep it lean
+
+---
+
+### Step 3: Approval Gate
+
+Present the plan to the user. Wait for explicit approval.
+
+**Acceptable approval signals:** "approved", "go", "do it", "ship it", "yes", "lgtm"
+
+**If the user has modifications:**
+1. Incorporate the changes
+2. Re-present the updated plan
+3. Wait for approval again
+
+**Do NOT proceed without clear approval.** Ambiguous responses like "hmm ok" or "I guess" are not approval — ask for clarification.
+
+---
+
+### Step 4: Agent Delegation
+
+After approval, spawn the appropriate agent:
+
+**Agent selection** (from Step 1 domain detection):
+
+- Use the Agent tool with `model: "sonnet"` (Sonnet 4.6) unless the user specifies otherwise
+- Pass the full approved plan as the agent's task description
+- Include relevant file paths and context the agent will need
+- For operator work: include the framework architecture pattern from CLAUDE.md
+- For composition work: include the composition directory structure
+- For testing: use the `@kaos-tester` agent definition
+
+**Agent prompt template:**
+```
+You are implementing the following approved plan:
+
+[Full plan from Step 2]
+
+Key context:
+- [Relevant CLAUDE.md patterns]
+- [Relevant existing code patterns]
+- [Any answers to questions from the plan]
+
+Implementation rules:
+- Follow the acceptance criteria exactly
+- Run tests after implementation
+- Do not make assumptions — if unclear, list what you need clarified
+```
+
+**For multi-domain work** (e.g., operator + compositions):
+- Spawn parallel agents if the work is independent
+- Use sequential agents if one depends on the other
+- Clearly scope each agent's responsibility
+
+---
+
+### Step 5: Handoff Summary
+
+After delegation, output a summary:
+
+```markdown
+## Delegated
+
+| Aspect | Detail |
+|--------|--------|
+| **Agent** | [agent type] (Sonnet 4.6) |
+| **Scope** | [what was delegated] |
+| **ACs to deliver** | AC-01, AC-02, AC-03 |
+| **Files** | [key files being modified] |
+
+The agent is now working on the implementation. Review its output against the acceptance criteria when complete.
+```
+
+Then stop. Do not continue working — the agent handles implementation.

--- a/plugins/kaos-debug-skills/skills/kaos-plan-and-delegate/manifest.json
+++ b/plugins/kaos-debug-skills/skills/kaos-plan-and-delegate/manifest.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "../../../../manifest.schema.json",
+  "name": "kaos-plan-and-delegate",
+  "type": "skill",
+  "version": "1.0.0",
+  "entry": "SKILL.md",
+  "description": "Streamlined plan-then-delegate workflow. Generates plans with acceptance criteria and no assumptions, waits for approval, then auto-spawns the right agent type based on work domain. All agents default to Sonnet 4.6.",
+  "produces": {
+    "chunk_types": [],
+    "label": "",
+    "output_path": ""
+  },
+  "consumes": {
+    "chunk_types": [],
+    "tools": ["kaos:knowledge", "kaos:schema"]
+  },
+  "dependencies": {
+    "skills": []
+  },
+  "tags": ["plan", "delegate", "workflow", "agent", "kaos"],
+  "author": "kaos-io",
+  "license": "Apache-2.0"
+}

--- a/plugins/kaos-prd-skills/.claude-plugin/plugin.json
+++ b/plugins/kaos-prd-skills/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "kaos-prd-skills",
-  "version": "1.2.0",
-  "description": "Full KAOS PRD lifecycle — create, start, advance, track progress, capture decisions, and complete Product Requirements Documents. Includes PR summary skill and automated PRD update reminders via hooks.",
+  "version": "1.3.0",
+  "description": "Full KAOS PRD lifecycle — create, start, advance, track progress, capture decisions, and complete Product Requirements Documents. Includes sprint orchestrator, PR summary skill, and automated PRD update reminders via hooks.",
   "author": {
     "name": "KubeCore",
     "email": "hello@kaos.kubecore.eu"

--- a/plugins/kaos-prd-skills/skills/kaos-prd-sprint/SKILL.md
+++ b/plugins/kaos-prd-skills/skills/kaos-prd-sprint/SKILL.md
@@ -1,0 +1,226 @@
+---
+name: kaos-prd-sprint
+description: PRD workflow orchestrator. Picks next AC, generates plan, delegates to agent, verifies, and auto-updates PRD progress. Replaces manual invocation of kaos-prd-next → plan → delegate → kaos-prd-update-progress.
+user-invocable: true
+---
+
+# KAOS PRD Sprint
+
+Orchestrates the full PRD implementation cycle in a single skill invocation. Instead of manually running `/kaos-prd-next`, crafting a plan, delegating to an agent, and then running `/kaos-prd-update-progress`, this skill handles the entire loop.
+
+**One command. Pick AC → Plan → Approve → Delegate → Verify → Update PRD → Next AC.**
+
+## Usage
+
+```
+/kaos-prd-sprint
+/kaos-prd-sprint [issue-id]
+```
+
+## Process
+
+---
+
+### Step 1: Identify Active PRD
+
+Follow the same detection logic as `kaos-prd-next`:
+
+If `[issue-id]` is provided — use it directly.
+
+If not — detect from context:
+1. Current branch: `feature/prd-[N]-*` → use PRD N
+2. Recent conversation: explicit PRD reference → use that
+3. Modified `knowledge/prds/*.md` file → use that PRD
+4. Ask the user
+
+Read the full PRD file. Build an internal model of all features, ACs, threats, and open questions with their statuses.
+
+---
+
+### Step 2: Pick Next AC
+
+Scan for the highest-priority unimplemented acceptance criterion.
+
+**Priority order** (same as `kaos-prd-next`):
+1. Fix a **failing** AC — broken things take absolute priority
+2. **Critical-path** feature AC — `Defer? = ❌`, dependencies met, lowest feature number
+3. Resolve **blocking open question** — if Q-N blocks the next critical-path item
+4. **High-leverage** feature AC — unlocks the most downstream work
+5. **Parallel-safe** AC — can run alongside current work
+
+**Query platform state to validate the pick:**
+```
+kaos:list(resource_type="KubeOrg")
+kaos:list(resource_type="KubePool")
+kaos:knowledge(query="[topic relevant to the AC]")
+```
+
+**Present the selection:**
+
+```markdown
+## Next: [AC-NN — Criterion Title]
+
+**From Feature:** F-NN — [Feature Name]
+
+**Why this AC:**
+[2-3 sentences — why this is highest priority right now]
+
+**Platform state:**
+[What MCP queries confirmed — prerequisites exist, resources are ready, etc.]
+
+**Dependencies satisfied:**
+[List prerequisite features/ACs and confirm they pass]
+
+**Constraints to respect:**
+[CON-NN constraints that apply]
+
+Confirm to proceed with planning?
+```
+
+Wait for user confirmation. If the user wants a different AC, switch to it.
+
+---
+
+### Step 3: Generate Plan
+
+Using the selected AC, produce a plan in the standard format:
+
+```markdown
+# Plan: [AC-NN — Title]
+
+## Objective
+[What this AC achieves, traced back to the PRD feature]
+
+## Acceptance Criteria
+[Copy the exact AC text from the PRD — this is what must pass]
+
+## Questions
+[Uncertainties — do not assume. If none, state "None."]
+
+## Constraints
+[CON-NN constraints from the PRD that apply to this work]
+
+## Implementation Steps
+1. [Ordered steps with file paths]
+2. [...]
+
+## Verification
+- [ ] [How to verify the AC passes]
+- [ ] [Additional checks]
+
+## Files to Modify
+- `path/to/file` — [what changes]
+```
+
+---
+
+### Step 4: Single Approval Gate
+
+Present the plan. Wait for explicit approval.
+
+This is the **only** approval gate in the entire sprint cycle. No further approvals needed for delegation or PRD updates.
+
+---
+
+### Step 5: Delegate
+
+After approval, determine the right agent based on the AC's domain:
+
+| AC Domain | Agent |
+|-----------|-------|
+| Operator/controller code | Developer agent |
+| Crossplane compositions | Developer agent |
+| Frontend/dashboard | Frontend agent |
+| API endpoints | Developer agent |
+| E2E/integration testing | @kaos-tester agent |
+
+**Spawn the agent** with `model: sonnet` (Sonnet 4.6) and the full approved plan.
+
+Include in the agent prompt:
+- The exact AC text from the PRD
+- Relevant constraints (CON-NN)
+- File paths from the plan
+- Framework patterns from CLAUDE.md
+- Instruction to run tests after implementation
+
+---
+
+### Step 6: Post-Implementation Verification
+
+After the agent completes, verify the work:
+
+1. **Run the verification steps** from the plan
+2. **Check the AC** — does the implementation satisfy the exact criterion text?
+3. **Run relevant tests** — `make test`, composition tests, or manual verification
+
+**Present results:**
+
+```markdown
+## Verification: AC-NN
+
+| Check | Result | Evidence |
+|-------|--------|----------|
+| [Verification step] | ✓/✗ | [command output or observation] |
+| [Test suite] | ✓/✗ | [test results] |
+
+**Verdict:** PASSED / FAILED
+```
+
+**If PASSED:**
+- Auto-update the PRD: mark AC-NN as `passed`
+- Follow the same process as `/kaos-prd-update-progress`:
+  - Update the AC status in the PRD file
+  - Commit the PRD update
+  - Output confirmation
+
+**If FAILED:**
+- Present the failure details
+- Ask the user:
+  - **Retry** — go back to Step 5 with additional context about the failure
+  - **Modify plan** — go back to Step 3 with adjusted approach
+  - **Skip** — mark as `pending` and move to next AC
+
+---
+
+### Step 7: Loop or Stop
+
+After completing an AC:
+
+```markdown
+## Sprint Progress
+
+| AC | Status | Time |
+|----|--------|------|
+| AC-01 | ✓ Passed | [timestamp] |
+| AC-02 | ✗ Skipped | [timestamp] |
+
+**Continue to next AC?**
+```
+
+- If **yes** → return to Step 2 with updated PRD model
+- If **no** → output sprint summary:
+
+```markdown
+## Sprint Summary
+
+**PRD:** [PRD title]
+**ACs completed:** [count]
+**ACs skipped:** [count]
+**ACs remaining:** [count]
+
+**Next recommended AC:** [from Step 2 analysis]
+
+Run `/kaos-prd-sprint` again to continue where you left off.
+```
+
+---
+
+## Key Differences from Manual Workflow
+
+| Manual | Sprint |
+|--------|--------|
+| `/kaos-prd-next` → read recommendation | Automatic AC selection |
+| Manually craft plan | Auto-generated from AC |
+| "pass to @agent-developer" | Auto-delegation by domain |
+| Wait, then `/kaos-prd-update-progress` | Auto-verification and update |
+| 4 skill invocations per AC | 1 skill invocation per sprint session |

--- a/plugins/kaos-prd-skills/skills/kaos-prd-sprint/manifest.json
+++ b/plugins/kaos-prd-skills/skills/kaos-prd-sprint/manifest.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "../../../../manifest.schema.json",
+  "name": "kaos-prd-sprint",
+  "type": "skill",
+  "version": "1.0.0",
+  "entry": "SKILL.md",
+  "description": "PRD workflow orchestrator that replaces 4 manual skill invocations with a single command. Picks next AC, generates plan, delegates to agent, verifies, and auto-updates PRD progress.",
+  "produces": {
+    "chunk_types": [],
+    "label": "",
+    "output_path": ""
+  },
+  "consumes": {
+    "chunk_types": ["feature-requirement", "acceptance-criterion", "constraint", "threat", "open-question"],
+    "tools": ["kaos:list", "kaos:get", "kaos:status", "kaos:knowledge"]
+  },
+  "dependencies": {
+    "skills": ["kaos-prd-start@^1.0.0", "kaos-prd-next@^1.0.0", "kaos-prd-update-progress@^1.0.0"]
+  },
+  "tags": ["prd", "sprint", "orchestration", "workflow", "kaos"],
+  "author": "kaos-io",
+  "license": "Apache-2.0"
+}


### PR DESCRIPTION
## Summary

Adds new agent skills derived from analysis of **112K conversation messages across 380 sessions**, targeting the most frequent workflow bottlenecks on the KAOS platform:

- **Debug loops** averaging 3-5 iterations before resolution (472 occurrences)
- **Composition debugging** as the #1 technical pain point (555 occurrences)
- **Manual plan→delegate ceremonies** repeated hundreds of times (304 plan + 544 delegation)
- **PRD workflow** requiring 4 separate skill invocations per acceptance criterion (287 occurrences)

### New Plugin: `kaos-debug-skills` (v1.0.0)

| Skill | Purpose |
|-------|---------|
| `/kaos-debug` | 5-phase structured debugging: auto-gather platform state → problem statement → root cause analysis → fix proposal → verification. Includes iteration tracker that forces hypothesis pivots after 3 failed attempts |
| `/kaos-composition-debug` | 7-step Crossplane composition validation: XRD alignment → provider health → patch chain tracing → rendered vs expected comparison → RBAC/ProviderConfig verification |
| `/kaos-plan-and-delegate` | Streamlined plan→approve→delegate workflow with auto work-domain detection (operator, compositions, frontend, testing) and Sonnet 4.6 agent spawning |

Includes a `PostToolUse` hook that suggests `/kaos-debug` when repeated error patterns are detected.

### New Skill: `/kaos-prd-sprint` (added to `kaos-prd-skills` v1.3.0)

Orchestrates the full PRD implementation cycle — replaces manual invocation of `/kaos-prd-next` → plan → delegate → `/kaos-prd-update-progress` with a single command that loops: **pick AC → generate plan → approve → delegate → verify → update PRD → next AC**.

### Files Changed

**New (12):**
- `plugins/kaos-debug-skills/` — full plugin package (plugin.json, hooks, 3 skills with manifests and references)
- `plugins/kaos-prd-skills/skills/kaos-prd-sprint/` — SKILL.md + manifest.json

**Modified (2):**
- `.claude-plugin/marketplace.json` — register kaos-debug-skills, bump kaos-prd-skills to v1.3.0
- `plugins/kaos-prd-skills/.claude-plugin/plugin.json` — version bump to v1.3.0

## Test plan

- [ ] Install `kaos-debug-skills` plugin and verify all 3 skills appear in `/skills` list
- [ ] Invoke `/kaos-debug` — verify it auto-gathers platform state before asking for problem description
- [ ] Invoke `/kaos-composition-debug` against a known healthy composition — verify no false positives
- [ ] Invoke `/kaos-plan-and-delegate` with a small task — verify plan format and agent delegation
- [ ] Invoke `/kaos-prd-sprint` against an active PRD — verify it picks next AC and consolidates the 4-step flow
- [ ] Verify `PostToolUse` hook fires after repeated Bash errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)